### PR TITLE
fix: Simple monitoring on rebalancer

### DIFF
--- a/typescript/cli/src/rebalancer/rebalancer.ts
+++ b/typescript/cli/src/rebalancer/rebalancer.ts
@@ -1,11 +1,65 @@
+import { IRegistry } from '@hyperlane-xyz/registry';
+import { ChainName, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { WarpCore } from '@hyperlane-xyz/sdk';
+import { objMap, objMerge } from '@hyperlane-xyz/utils';
+
+import { logTable } from '../logger.js';
+
 export class HyperlaneRebalancer {
-  start(): void {
-    // Placeholder to simulate a long running process.
-    // The real implementation will be added later.
-    setInterval(() => {}, 1000);
+  private interval: NodeJS.Timeout | undefined;
+
+  constructor(
+    private readonly registry: IRegistry,
+    private readonly warpRouteId: string,
+    private readonly checkFrequency: number,
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.interval) {
+      throw new Error('Rebalancer already running');
+    }
+
+    const chainMetadata = await this.registry.getMetadata();
+    const chainAddresses = await this.registry.getAddresses();
+    const mailboxes = objMap(chainAddresses, (_, { mailbox }) => ({
+      mailbox,
+    }));
+    const multiProtocolProvider = new MultiProtocolProvider(
+      objMerge(chainMetadata, mailboxes),
+    );
+    const warpCoreConfig = await this.registry.getWarpRoute(this.warpRouteId);
+    const warpCore = WarpCore.FromConfig(multiProtocolProvider, warpCoreConfig);
+    const collateralTokens = warpCore.tokens.filter((token) =>
+      token.isCollateralized(),
+    );
+
+    this.interval = setInterval(async () => {
+      const collaterals: {
+        name: ChainName;
+        collateral: number;
+        symbol: string;
+      }[] = [];
+
+      for (const token of collateralTokens) {
+        const adapter = token.getHypAdapter(multiProtocolProvider);
+        const bridgedSupply = await adapter.getBridgedSupply();
+        const collateral = token
+          .amount(bridgedSupply!)
+          .getDecimalFormattedAmount();
+        collaterals.push({
+          name: token.chainName,
+          collateral,
+          symbol: token.symbol,
+        });
+      }
+
+      logTable(collaterals);
+    }, this.checkFrequency);
   }
 
   stop(): void {
-    // Implement
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
   }
 }


### PR DESCRIPTION
Closes #13 

Like the original monitor, rebalancer accepts the warp route and frequency to query for collateral.
```bash
yarn workspace @hyperlane-xyz/cli hyperlane warp rebalancer \
    --warpRouteId TKN/anvil1-anvil2-anvil3 \
    --check-frequency 5000
```
Renders the current collaterals every 5 seconds.

<img width="316" alt="Screenshot 2025-04-10 at 5 12 28 PM" src="https://github.com/user-attachments/assets/bb260c5f-ddc4-4a78-8095-56ec57a1e447" />
