### PR TITLE
fix: Add rebalancer monitor e2e test

### DIFF
--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -6,14 +6,16 @@ function cleanup() {
   rm -rf ./tmp
   rm -f ./test-configs/anvil/chains/anvil2/addresses.yaml
   rm -f ./test-configs/anvil/chains/anvil3/addresses.yaml
+  rm -f ./test-configs/anvil/chains/anvil4/addresses.yaml
   set -e
 }
 
 cleanup
 
-echo "Starting anvil2 and anvil3 chain for E2E tests"
+echo "Starting anvil2, anvil3 and anvil4 chains for E2E tests"
 anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 > /dev/null &
 anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 > /dev/null &
+anvil --chain-id 31348 -p 8601 --state /tmp/anvil4/state --gas-price 1 > /dev/null &
 
 echo "Running E2E tests"
 if [ -n "${CLI_E2E_TEST}" ]; then

--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -4,9 +4,9 @@ function cleanup() {
   set +e
   pkill -f anvil
   rm -rf ./test-configs/anvil/deployments
-  rm -f  ./test-configs/anvil/chains/anvil2/addresses.yaml
-  rm -f  ./test-configs/anvil/chains/anvil3/addresses.yaml
-  rm -f  ./test-configs/anvil/chains/anvil4/addresses.yaml
+  rm -f ./test-configs/anvil/chains/anvil2/addresses.yaml
+  rm -f ./test-configs/anvil/chains/anvil3/addresses.yaml
+  rm -f ./test-configs/anvil/chains/anvil4/addresses.yaml
   set -e
 }
 

--- a/typescript/cli/scripts/run-e2e-test.sh
+++ b/typescript/cli/scripts/run-e2e-test.sh
@@ -3,19 +3,19 @@
 function cleanup() {
   set +e
   pkill -f anvil
-  rm -rf ./tmp
-  rm -f ./test-configs/anvil/chains/anvil2/addresses.yaml
-  rm -f ./test-configs/anvil/chains/anvil3/addresses.yaml
-  rm -f ./test-configs/anvil/chains/anvil4/addresses.yaml
+  rm -rf ./test-configs/anvil/deployments
+  rm -f  ./test-configs/anvil/chains/anvil2/addresses.yaml
+  rm -f  ./test-configs/anvil/chains/anvil3/addresses.yaml
+  rm -f  ./test-configs/anvil/chains/anvil4/addresses.yaml
   set -e
 }
 
 cleanup
 
 echo "Starting anvil2, anvil3 and anvil4 chains for E2E tests"
-anvil --chain-id 31338 -p 8555 --state /tmp/anvil2/state --gas-price 1 > /dev/null &
-anvil --chain-id 31347 -p 8600 --state /tmp/anvil3/state --gas-price 1 > /dev/null &
-anvil --chain-id 31348 -p 8601 --state /tmp/anvil4/state --gas-price 1 > /dev/null &
+anvil --chain-id 31338 -p 8555 --gas-price 1 > /dev/null &
+anvil --chain-id 31347 -p 8600 --gas-price 1 > /dev/null &
+anvil --chain-id 31348 -p 8601 --gas-price 1 > /dev/null &
 
 echo "Running E2E tests"
 if [ -n "${CLI_E2E_TEST}" ]; then

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -45,6 +45,7 @@ export const E2E_TEST_BURN_ADDRESS =
 
 export const CHAIN_NAME_2 = 'anvil2';
 export const CHAIN_NAME_3 = 'anvil3';
+export const CHAIN_NAME_4 = 'anvil4';
 
 export const EXAMPLES_PATH = './examples';
 export const CORE_CONFIG_PATH = `${EXAMPLES_PATH}/core-config.yaml`;

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -142,7 +142,7 @@ export function hyperlaneWarpSendRelay(
   destination: string,
   warpCorePath: string,
   relay = true,
-  value = 1,
+  value: number | string = 1,
 ): ProcessPromise {
   return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp send \
         ${relay ? '--relay' : ''} \

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -156,8 +156,14 @@ export function hyperlaneWarpSendRelay(
         --amount ${value}`;
 }
 
-export function hyperlaneWarpRebalancer(): ProcessPromise {
-  return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp rebalancer`;
+export function hyperlaneWarpRebalancer(
+  warpRouteId: string,
+  checkFrequency: number,
+): ProcessPromise {
+  return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp rebalancer \
+        --registry ${REGISTRY_PATH} \
+        --warpRouteId ${warpRouteId} \
+        --checkFrequency ${checkFrequency}`;
 }
 
 /**

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -1,33 +1,104 @@
-import { expect } from 'chai';
+import { Wallet } from 'ethers';
 
-import { sleep } from '@hyperlane-xyz/utils';
+import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
+import { TokenType, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
 
-import { DEFAULT_E2E_TEST_TIMEOUT } from '../commands/helpers.js';
-import { hyperlaneWarpRebalancer } from '../commands/warp.js';
+import { writeYamlOrJson } from '../../utils/files.js';
+import {
+  ANVIL_KEY,
+  CHAIN_NAME_2,
+  CHAIN_NAME_3,
+  CHAIN_NAME_4,
+  CORE_CONFIG_PATH,
+  DEFAULT_E2E_TEST_TIMEOUT,
+  deployOrUseExistingCore,
+  deployToken,
+  getCombinedWarpRoutePath,
+} from '../commands/helpers.js';
+import {
+  hyperlaneWarpDeploy,
+  hyperlaneWarpRebalancer,
+} from '../commands/warp.js';
 
 describe('hyperlane warp rebalancer e2e tests', async function () {
   this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
 
   describe('hyperlane warp rebalancer', () => {
     it('should successfully start and stop the warp rebalancer', async function () {
-      // Start the process
-      const process = hyperlaneWarpRebalancer().stdio('pipe');
+      // Deploy core contracts on all chains
+      const chain2Addresses = await deployOrUseExistingCore(
+        CHAIN_NAME_2,
+        CORE_CONFIG_PATH,
+        ANVIL_KEY,
+      );
+      const chain3Addresses = await deployOrUseExistingCore(
+        CHAIN_NAME_3,
+        CORE_CONFIG_PATH,
+        ANVIL_KEY,
+      );
+      const chain4Addresses = await deployOrUseExistingCore(
+        CHAIN_NAME_4,
+        CORE_CONFIG_PATH,
+        ANVIL_KEY,
+      );
 
-      // Wait for the process to start
-      await sleep(5000);
+      // Deploy ERC20s
+      const tokenChain2 = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
+      const tokenChain3 = await deployToken(ANVIL_KEY, CHAIN_NAME_3);
+      const tokenSymbol = await tokenChain2.symbol();
 
-      // Stop the process
-      await process.kill('SIGINT');
+      // Deploy Warp Route
+      const warpDeploymentPath = getCombinedWarpRoutePath(tokenSymbol, [
+        CHAIN_NAME_2,
+        CHAIN_NAME_3,
+        CHAIN_NAME_4,
+      ]);
+      const ownerAddress = new Wallet(ANVIL_KEY).address;
+      const warpConfig: WarpRouteDeployConfig = {
+        [CHAIN_NAME_2]: {
+          type: TokenType.collateral,
+          token: tokenChain2.address,
+          mailbox: chain2Addresses.mailbox,
+          owner: ownerAddress,
+        },
+        [CHAIN_NAME_3]: {
+          type: TokenType.collateral,
+          token: tokenChain3.address,
+          mailbox: chain3Addresses.mailbox,
+          owner: ownerAddress,
+        },
+        [CHAIN_NAME_4]: {
+          type: TokenType.synthetic,
+          mailbox: chain4Addresses.mailbox,
+          owner: ownerAddress,
+        },
+      };
+      writeYamlOrJson(warpDeploymentPath, warpConfig);
+      await hyperlaneWarpDeploy(warpDeploymentPath);
 
-      // Wait for the process to stop
-      await sleep(1000);
+      // Start the rebalancer
+      const warpRouteId = createWarpRouteConfigId(tokenSymbol.toUpperCase(), [
+        CHAIN_NAME_2,
+        CHAIN_NAME_3,
+        CHAIN_NAME_4,
+      ]);
+      const process = hyperlaneWarpRebalancer(warpRouteId, 1000);
 
-      // Get the output
-      const text = await process.text();
-
-      // Verify the output contains the expected messages
-      expect(text).to.include('Starting rebalancer ...');
-      expect(text).to.include('Stopping rebalancer ...');
+      // Verify that one of the logs corresponds to the collateral.
+      for await (const chunk of process.stdout) {
+        if (
+          chunk.includes(`┌─────────┬──────────┬────────────┬─────────┐
+│ (index) │ name     │ collateral │ symbol  │
+├─────────┼──────────┼────────────┼─────────┤
+│ 0       │ 'anvil2' │ 0          │ 'TOKEN' │
+│ 1       │ 'anvil3' │ 0          │ 'TOKEN' │
+└─────────┴──────────┴────────────┴─────────┘
+`)
+        ) {
+          process.kill('SIGINT');
+          break;
+        }
+      }
     });
   });
 });

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -2,6 +2,7 @@ import { Wallet } from 'ethers';
 
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { TokenType, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
+import { toWei } from '@hyperlane-xyz/utils';
 
 import { writeYamlOrJson } from '../../utils/files.js';
 import {
@@ -18,6 +19,7 @@ import {
 import {
   hyperlaneWarpDeploy,
   hyperlaneWarpRebalancer,
+  hyperlaneWarpSendRelay,
 } from '../commands/warp.js';
 
 describe('hyperlane warp rebalancer e2e tests', async function () {
@@ -76,6 +78,22 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       writeYamlOrJson(warpDeploymentPath, warpConfig);
       await hyperlaneWarpDeploy(warpDeploymentPath);
 
+      // Bridge tokens from the collateral chains to the synthetic
+      await hyperlaneWarpSendRelay(
+        CHAIN_NAME_2,
+        CHAIN_NAME_4,
+        warpDeploymentPath,
+        true,
+        toWei(49),
+      );
+      await hyperlaneWarpSendRelay(
+        CHAIN_NAME_3,
+        CHAIN_NAME_4,
+        warpDeploymentPath,
+        true,
+        toWei(51),
+      );
+
       // Start the rebalancer
       const warpRouteId = createWarpRouteConfigId(tokenSymbol.toUpperCase(), [
         CHAIN_NAME_2,
@@ -84,14 +102,14 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       ]);
       const process = hyperlaneWarpRebalancer(warpRouteId, 1000);
 
-      // Verify that one of the logs corresponds to the collateral.
+      // Verify that it logs the correct collateral
       for await (const chunk of process.stdout) {
         if (
           chunk.includes(`┌─────────┬──────────┬────────────┬─────────┐
 │ (index) │ name     │ collateral │ symbol  │
 ├─────────┼──────────┼────────────┼─────────┤
-│ 0       │ 'anvil2' │ 0          │ 'TOKEN' │
-│ 1       │ 'anvil3' │ 0          │ 'TOKEN' │
+│ 0       │ 'anvil2' │ 49         │ 'TOKEN' │
+│ 1       │ 'anvil3' │ 51         │ 'TOKEN' │
 └─────────┴──────────┴────────────┴─────────┘
 `)
         ) {

--- a/typescript/cli/test-configs/anvil/chains/anvil4/metadata.yaml
+++ b/typescript/cli/test-configs/anvil/chains/anvil4/metadata.yaml
@@ -1,0 +1,22 @@
+# Configs for describing chain metadata for use in Hyperlane deployments or apps
+# Consists of a map of chain names to metadata
+# Schema here: https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/main/typescript/sdk/src/metadata/chainMetadataTypes.ts
+---
+chainId: 31348
+domainId: 31348
+name: anvil4
+protocol: ethereum
+rpcUrls:
+  - http: http://127.0.0.1:8601
+blockExplorers: # Array: List of BlockExplorer configs
+  # Required fields:
+  - name: My Chain Explorer # String: Human-readable name for the explorer
+    url: https://mychain.com/explorer # String: Base URL for the explorer
+    apiUrl: https://mychain.com/api # String: Base URL for the explorer API
+    # Optional fields:
+    apiKey: myapikey # String: API key for the explorer (optional)
+    family: etherscan # ExplorerFamily: See ExplorerFamily for valid values
+nativeToken:
+  name: Ether
+  symbol: ETH
+  decimals: 18


### PR DESCRIPTION
Closes #15 

Adds a test in which it asserts that the rebalancer is obtaining the collaterals of the provided warp route.

The test contains the following:
- Deploy core contracts on all chains
- Deploy collateral tokens on anvil 2 and 3, (anvil 4 is for the synthetic)
- Deploy warp route
- Bridge from anvil 1 -> anvil 3 and anvil 2 -> anvil 3
- Start the rebalancer
- Assert the collaterals queried correspond to the amount bridged