### PR TITLE
fix: Add tolerance to simple strategy

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -429,7 +429,8 @@ export const rebalancer: CommandModuleWithContext<{
     },
     strategyTolerance: {
       type: 'string',
-      description: 'Threshold for balance to be considered unbalanced',
+      description:
+        'Tolerance threshold for imbalance detection (specified in token base units; e.g., 1000000 for 1 USDC, 1000000000000000000 for 1 ETH)',
       demandOption: false,
       default: '0',
     },

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -411,6 +411,7 @@ export const check: CommandModuleWithContext<{
 export const rebalancer: CommandModuleWithContext<{
   warpRouteId: string;
   checkFrequency: number;
+  strategyTolerance: string;
 }> = {
   command: 'rebalancer',
   describe: 'Run a warp route collateral rebalancer',
@@ -426,8 +427,19 @@ export const rebalancer: CommandModuleWithContext<{
       demandOption: true,
       alias: 'v',
     },
+    strategyTolerance: {
+      type: 'string',
+      description: 'Threshold for balance to be considered unbalanced',
+      demandOption: false,
+      default: '0',
+    },
   },
-  handler: async ({ context, warpRouteId, checkFrequency }) => {
+  handler: async ({
+    context,
+    warpRouteId,
+    checkFrequency,
+    strategyTolerance,
+  }) => {
     logCommandHeader('Hyperlane Warp Rebalancer');
 
     // Instantiates the warp route monitor
@@ -438,7 +450,7 @@ export const rebalancer: CommandModuleWithContext<{
     );
 
     // Instantiates the strategy that will get rebalancing routes based on monitor results
-    const strategy: IStrategy = new Strategy();
+    const strategy: IStrategy = new Strategy(BigInt(strategyTolerance));
 
     // Instantiates the executor that will process rebalancing routes
     const executor: IExecutor = new Executor();

--- a/typescript/cli/src/rebalancer/strategy/Strategy.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/Strategy.test.ts
@@ -87,7 +87,50 @@ describe('Strategy', () => {
     it('should return no routes', () => {
       const routes = strategy.getRebalancingRoutes(balances);
 
-      expect(routes).to.have.lengthOf(0);
+      expect(routes).to.be.empty;
+    });
+  });
+
+  describe('when tolerance is 10 ether', () => {
+    beforeEach(() => {
+      strategy = new Strategy(ethers.utils.parseEther('10').toBigInt());
+    });
+
+    describe('when balances for chain1, chain2, and chain3 are 80, 90, and 100 respectively', () => {
+      beforeEach(() => {
+        balances = {
+          [chain1]: ethers.utils.parseEther('80').toBigInt(),
+          [chain2]: ethers.utils.parseEther('90').toBigInt(),
+          [chain3]: ethers.utils.parseEther('100').toBigInt(),
+        };
+      });
+
+      it('should return no routes', () => {
+        const routes = strategy.getRebalancingRoutes(balances);
+
+        expect(routes).to.be.empty;
+      });
+    });
+
+    describe('when balances for chain1, chain2, and chain3 are 70, 90, and 110 respectively', () => {
+      beforeEach(() => {
+        balances = {
+          [chain1]: ethers.utils.parseEther('70').toBigInt(),
+          [chain2]: ethers.utils.parseEther('90').toBigInt(),
+          [chain3]: ethers.utils.parseEther('110').toBigInt(),
+        };
+      });
+
+      it('should return one route for 20 from chain3 to chain1', () => {
+        const routes = strategy.getRebalancingRoutes(balances);
+
+        expect(routes).to.have.lengthOf(1);
+        expect(routes[0]).to.deep.equal({
+          fromChain: 'chain3',
+          toChain: 'chain1',
+          amount: ethers.utils.parseEther('20').toBigInt(),
+        });
+      });
     });
   });
 });

--- a/typescript/cli/src/rebalancer/strategy/Strategy.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/Strategy.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 
 import { ChainName } from '@hyperlane-xyz/sdk';
 
-import { Strategy } from './Strategy.js';
+import { Route, Strategy } from './Strategy.js';
 
 describe('Strategy', () => {
   let chain1: ChainName;
@@ -45,7 +45,7 @@ describe('Strategy', () => {
         fromChain: 'chain3',
         toChain: 'chain1',
         amount: ethers.utils.parseEther('100').toBigInt(),
-      });
+      } as Route);
     });
   });
 
@@ -66,12 +66,12 @@ describe('Strategy', () => {
         fromChain: 'chain3',
         toChain: 'chain1',
         amount: 66666666666666666666n, // 66
-      });
+      } as Route);
       expect(routes[1]).to.deep.equal({
         fromChain: 'chain3',
         toChain: 'chain2',
         amount: 66666666666666666666n, // 66
-      });
+      } as Route);
     });
   });
 

--- a/typescript/cli/src/rebalancer/strategy/Strategy.test.ts
+++ b/typescript/cli/src/rebalancer/strategy/Strategy.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'ethers';
 
 import { ChainName } from '@hyperlane-xyz/sdk';
 
-import { Route, Strategy } from './Strategy.js';
+import { Strategy } from './Strategy.js';
 
 describe('Strategy', () => {
   let chain1: ChainName;
@@ -45,7 +45,7 @@ describe('Strategy', () => {
         fromChain: 'chain3',
         toChain: 'chain1',
         amount: ethers.utils.parseEther('100').toBigInt(),
-      } as Route);
+      });
     });
   });
 
@@ -66,12 +66,12 @@ describe('Strategy', () => {
         fromChain: 'chain3',
         toChain: 'chain1',
         amount: 66666666666666666666n, // 66
-      } as Route);
+      });
       expect(routes[1]).to.deep.equal({
         fromChain: 'chain3',
         toChain: 'chain2',
         amount: 66666666666666666666n, // 66
-      } as Route);
+      });
     });
   });
 

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -20,7 +20,7 @@ import {
   WarpCoreConfig,
   WarpCoreConfigSchema,
 } from '@hyperlane-xyz/sdk';
-import { Address, sleep } from '@hyperlane-xyz/utils';
+import { Address, assert, sleep } from '@hyperlane-xyz/utils';
 
 import { getContext } from '../../context/context.js';
 import { CommandContext } from '../../context/types.js';
@@ -53,6 +53,7 @@ export const CORE_CONFIG_PATH_2 = `${TEMP_PATH}/${CHAIN_NAME_2}/core-config.yaml
 export const CORE_READ_CONFIG_PATH_2 = `${TEMP_PATH}/${CHAIN_NAME_2}/core-config-read.yaml`;
 export const CHAIN_2_METADATA_PATH = `${REGISTRY_PATH}/chains/${CHAIN_NAME_2}/metadata.yaml`;
 export const CHAIN_3_METADATA_PATH = `${REGISTRY_PATH}/chains/${CHAIN_NAME_3}/metadata.yaml`;
+export const CHAIN_4_METADATA_PATH = `${REGISTRY_PATH}/chains/${CHAIN_NAME_4}/metadata.yaml`;
 
 export const WARP_CONFIG_PATH_EXAMPLE = `${EXAMPLES_PATH}/warp-route-deployment.yaml`;
 export const WARP_CONFIG_PATH_2 = `${TEMP_PATH}/${CHAIN_NAME_2}/warp-route-deployment-anvil2.yaml`;
@@ -515,4 +516,39 @@ export function hyperlaneRelayer(chains: string[], warp?: string) {
         --key ${ANVIL_KEY} \
         --verbosity debug \
         --yes`;
+}
+
+export async function createSnapshot(rpcUrl: string): Promise<string> {
+  return await snapshotBaseCall<string>(rpcUrl, 'evm_snapshot', []);
+}
+
+export async function restoreSnapshot(
+  rpcUrl: string,
+  snapshotId: string,
+): Promise<void> {
+  const result = await snapshotBaseCall<boolean>(rpcUrl, 'evm_revert', [
+    snapshotId,
+  ]);
+  assert(result, 'Failed to restore snapshot');
+}
+
+async function snapshotBaseCall<T>(
+  rpcUrl: string,
+  method: string,
+  params: any[],
+): Promise<T> {
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      id: 1337,
+      jsonrpc: '2.0',
+      method,
+      params,
+    }),
+  });
+  const { result } = await response.json();
+  return result;
 }

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -159,11 +159,19 @@ export function hyperlaneWarpSendRelay(
 export function hyperlaneWarpRebalancer(
   warpRouteId: string,
   checkFrequency: number,
+  options: {
+    strategyTolerance?: bigint;
+  } = {},
 ): ProcessPromise {
   return $`yarn workspace @hyperlane-xyz/cli run hyperlane warp rebalancer \
         --registry ${REGISTRY_PATH} \
         --warpRouteId ${warpRouteId} \
-        --checkFrequency ${checkFrequency}`;
+        --checkFrequency ${checkFrequency} \
+        ${
+          options.strategyTolerance
+            ? ['--strategyTolerance', options.strategyTolerance]
+            : ''
+        }`;
 }
 
 /**

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -169,7 +169,7 @@ export function hyperlaneWarpRebalancer(
         --checkFrequency ${checkFrequency} \
         ${
           options.strategyTolerance
-            ? ['--strategyTolerance', options.strategyTolerance]
+            ? `--strategyTolerance ${options.strategyTolerance}`
             : ''
         }`;
 }

--- a/typescript/cli/src/tests/commands/warp.ts
+++ b/typescript/cli/src/tests/commands/warp.ts
@@ -169,7 +169,7 @@ export function hyperlaneWarpRebalancer(
         --checkFrequency ${checkFrequency} \
         ${
           options.strategyTolerance
-            ? `--strategyTolerance ${options.strategyTolerance}`
+            ? ['--strategyTolerance', options.strategyTolerance]
             : ''
         }`;
 }

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -211,14 +211,14 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
           CHAIN_NAME_4,
           warpDeploymentPath,
           true,
-          toWei(30),
+          toWei(40),
         ),
         hyperlaneWarpSendRelay(
           CHAIN_NAME_3,
           CHAIN_NAME_4,
           warpDeploymentPath,
           true,
-          toWei(70),
+          toWei(60),
         ),
       ]);
 
@@ -235,7 +235,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   {
     fromChain: 'anvil3',
     toChain: 'anvil2',
-    amount: 20000000000000000000n
+    amount: 10000000000000000000n
   }
 ]`,
           )
@@ -243,6 +243,20 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
           break;
         }
       }
+    });
+
+    describe('with strategy tolerance of 10 ether', () => {
+      it.only('should report an empty array of routes being executed', async () => {
+        process = hyperlaneWarpRebalancer(warpRouteId, CHECK_FREQUENCY, {
+          strategyTolerance: BigInt(toWei(10)),
+        });
+
+        for await (const chunk of process.stdout) {
+          if (chunk.includes('Executing rebalancing routes: []')) {
+            break;
+          }
+        }
+      });
     });
   });
 });

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -28,25 +28,18 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   describe('hyperlane warp rebalancer', () => {
     it('should successfully start and stop the warp rebalancer', async function () {
       // Deploy core contracts on all chains
-      const chain2Addresses = await deployOrUseExistingCore(
-        CHAIN_NAME_2,
-        CORE_CONFIG_PATH,
-        ANVIL_KEY,
-      );
-      const chain3Addresses = await deployOrUseExistingCore(
-        CHAIN_NAME_3,
-        CORE_CONFIG_PATH,
-        ANVIL_KEY,
-      );
-      const chain4Addresses = await deployOrUseExistingCore(
-        CHAIN_NAME_4,
-        CORE_CONFIG_PATH,
-        ANVIL_KEY,
-      );
+      const [chain2Addresses, chain3Addresses, chain4Addresses] =
+        await Promise.all([
+          deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+          deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+          deployOrUseExistingCore(CHAIN_NAME_4, CORE_CONFIG_PATH, ANVIL_KEY),
+        ]);
 
       // Deploy ERC20s
-      const tokenChain2 = await deployToken(ANVIL_KEY, CHAIN_NAME_2);
-      const tokenChain3 = await deployToken(ANVIL_KEY, CHAIN_NAME_3);
+      const [tokenChain2, tokenChain3] = await Promise.all([
+        deployToken(ANVIL_KEY, CHAIN_NAME_2),
+        deployToken(ANVIL_KEY, CHAIN_NAME_3),
+      ]);
       const tokenSymbol = await tokenChain2.symbol();
 
       // Deploy Warp Route
@@ -79,20 +72,22 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       await hyperlaneWarpDeploy(warpDeploymentPath);
 
       // Bridge tokens from the collateral chains to the synthetic
-      await hyperlaneWarpSendRelay(
-        CHAIN_NAME_2,
-        CHAIN_NAME_4,
-        warpDeploymentPath,
-        true,
-        toWei(49),
-      );
-      await hyperlaneWarpSendRelay(
-        CHAIN_NAME_3,
-        CHAIN_NAME_4,
-        warpDeploymentPath,
-        true,
-        toWei(51),
-      );
+      await Promise.all([
+        hyperlaneWarpSendRelay(
+          CHAIN_NAME_2,
+          CHAIN_NAME_4,
+          warpDeploymentPath,
+          true,
+          toWei(49),
+        ),
+        hyperlaneWarpSendRelay(
+          CHAIN_NAME_3,
+          CHAIN_NAME_4,
+          warpDeploymentPath,
+          true,
+          toWei(51),
+        ),
+      ]);
 
       // Start the rebalancer
       const warpRouteId = createWarpRouteConfigId(tokenSymbol.toUpperCase(), [

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -8,7 +8,7 @@ import {
   TokenType,
   WarpRouteDeployConfig,
 } from '@hyperlane-xyz/sdk';
-import { toWei } from '@hyperlane-xyz/utils';
+import { sleep, toWei } from '@hyperlane-xyz/utils';
 
 import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
 import {
@@ -177,12 +177,14 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
           true,
           toWei(50),
         ),
-        hyperlaneWarpSendRelay(
-          CHAIN_NAME_3,
-          CHAIN_NAME_4,
-          warpDeploymentPath,
-          true,
-          toWei(50),
+        sleep(1000).then(() =>
+          hyperlaneWarpSendRelay(
+            CHAIN_NAME_3,
+            CHAIN_NAME_4,
+            warpDeploymentPath,
+            true,
+            toWei(50),
+          ),
         ),
       ]);
 
@@ -213,12 +215,14 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
           true,
           toWei(40),
         ),
-        hyperlaneWarpSendRelay(
-          CHAIN_NAME_3,
-          CHAIN_NAME_4,
-          warpDeploymentPath,
-          true,
-          toWei(60),
+        sleep(1000).then(() =>
+          hyperlaneWarpSendRelay(
+            CHAIN_NAME_3,
+            CHAIN_NAME_4,
+            warpDeploymentPath,
+            true,
+            toWei(60),
+          ),
         ),
       ]);
 

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -246,7 +246,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
 
     describe('with strategy tolerance of 10 ether', () => {
-      it.only('should report an empty array of routes being executed', async () => {
+      it('should report an empty array of routes being executed', async () => {
         process = hyperlaneWarpRebalancer(warpRouteId, CHECK_FREQUENCY, {
           strategyTolerance: BigInt(toWei(10)),
         });

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -3,20 +3,29 @@ import { ProcessPromise } from 'zx';
 import { $ } from 'zx';
 
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
-import { TokenType, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
-import { assert, toWei } from '@hyperlane-xyz/utils';
+import {
+  ChainMetadata,
+  TokenType,
+  WarpRouteDeployConfig,
+} from '@hyperlane-xyz/sdk';
+import { toWei } from '@hyperlane-xyz/utils';
 
-import { writeYamlOrJson } from '../../utils/files.js';
+import { readYamlOrJson, writeYamlOrJson } from '../../utils/files.js';
 import {
   ANVIL_KEY,
+  CHAIN_2_METADATA_PATH,
+  CHAIN_3_METADATA_PATH,
+  CHAIN_4_METADATA_PATH,
   CHAIN_NAME_2,
   CHAIN_NAME_3,
   CHAIN_NAME_4,
   CORE_CONFIG_PATH,
   DEFAULT_E2E_TEST_TIMEOUT,
+  createSnapshot,
   deployOrUseExistingCore,
   deployToken,
   getCombinedWarpRoutePath,
+  restoreSnapshot,
 } from '../commands/helpers.js';
 import {
   hyperlaneWarpDeploy,
@@ -34,43 +43,8 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   let warpRouteId: string;
 
   let process: ProcessPromise | undefined;
-  let snapshot1: string;
-  let snapshot2: string;
-  let snapshot3: string;
 
-  async function createSnapshot(rpcUrl: string): Promise<string> {
-    const response = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        id: 1337,
-        jsonrpc: '2.0',
-        method: 'evm_snapshot',
-        params: [],
-      }),
-    });
-    const data = await response.json();
-    return data.result;
-  }
-
-  async function restoreSnapshot(rpcUrl: string, snapshot: string) {
-    const response = await fetch(rpcUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        id: 1337,
-        jsonrpc: '2.0',
-        method: 'evm_revert',
-        params: [snapshot],
-      }),
-    });
-    const data = await response.json();
-    assert(data.result, 'Failed to revert snapshot');
-  }
+  let snapshots: { rpcUrl: string; snapshotId: string }[] = [];
 
   before(async () => {
     const ogVerbose = $.verbose;
@@ -132,9 +106,28 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   beforeEach(async () => {
     process = undefined;
 
-    snapshot1 = await createSnapshot('http://localhost:8555');
-    snapshot2 = await createSnapshot('http://localhost:8600');
-    snapshot3 = await createSnapshot('http://localhost:8601');
+    const chain2Metadata: ChainMetadata = readYamlOrJson(CHAIN_2_METADATA_PATH);
+    const chain3Metadata: ChainMetadata = readYamlOrJson(CHAIN_3_METADATA_PATH);
+    const chain4Metadata: ChainMetadata = readYamlOrJson(CHAIN_4_METADATA_PATH);
+
+    const chain2RpcUrl = chain2Metadata.rpcUrls[0].http;
+    const chain3RpcUrl = chain3Metadata.rpcUrls[0].http;
+    const chain4RpcUrl = chain4Metadata.rpcUrls[0].http;
+
+    snapshots = [
+      {
+        rpcUrl: chain2RpcUrl,
+        snapshotId: await createSnapshot(chain2RpcUrl),
+      },
+      {
+        rpcUrl: chain3RpcUrl,
+        snapshotId: await createSnapshot(chain3RpcUrl),
+      },
+      {
+        rpcUrl: chain4RpcUrl,
+        snapshotId: await createSnapshot(chain4RpcUrl),
+      },
+    ];
   });
 
   afterEach(async () => {
@@ -142,9 +135,11 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       await process.kill();
     }
 
-    await restoreSnapshot('http://localhost:8555', snapshot1);
-    await restoreSnapshot('http://localhost:8600', snapshot2);
-    await restoreSnapshot('http://localhost:8601', snapshot3);
+    await Promise.all(
+      snapshots.map(({ rpcUrl, snapshotId }) =>
+        restoreSnapshot(rpcUrl, snapshotId),
+      ),
+    );
   });
 
   it('should successfuly start the rebalancer', async () => {

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -1,8 +1,10 @@
 import { Wallet } from 'ethers';
+import { ProcessPromise } from 'zx';
+import { $ } from 'zx';
 
 import { createWarpRouteConfigId } from '@hyperlane-xyz/registry';
 import { TokenType, WarpRouteDeployConfig } from '@hyperlane-xyz/sdk';
-import { toWei } from '@hyperlane-xyz/utils';
+import { assert, toWei } from '@hyperlane-xyz/utils';
 
 import { writeYamlOrJson } from '../../utils/files.js';
 import {
@@ -25,90 +27,224 @@ import {
 describe('hyperlane warp rebalancer e2e tests', async function () {
   this.timeout(2 * DEFAULT_E2E_TEST_TIMEOUT);
 
-  describe('hyperlane warp rebalancer', () => {
-    it('should successfully start and stop the warp rebalancer', async function () {
-      // Deploy core contracts on all chains
-      const [chain2Addresses, chain3Addresses, chain4Addresses] =
-        await Promise.all([
-          deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
-          deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
-          deployOrUseExistingCore(CHAIN_NAME_4, CORE_CONFIG_PATH, ANVIL_KEY),
-        ]);
+  const CHECK_FREQUENCY = 1000;
 
-      // Deploy ERC20s
-      const [tokenChain2, tokenChain3] = await Promise.all([
-        deployToken(ANVIL_KEY, CHAIN_NAME_2),
-        deployToken(ANVIL_KEY, CHAIN_NAME_3),
+  let warpDeploymentPath: string;
+  let tokenSymbol: string;
+  let warpRouteId: string;
+
+  let process: ProcessPromise | undefined;
+  let snapshot1: string;
+  let snapshot2: string;
+  let snapshot3: string;
+
+  async function createSnapshot(rpcUrl: string): Promise<string> {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1337,
+        jsonrpc: '2.0',
+        method: 'evm_snapshot',
+        params: [],
+      }),
+    });
+    const data = await response.json();
+    return data.result;
+  }
+
+  async function restoreSnapshot(rpcUrl: string, snapshot: string) {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: 1337,
+        jsonrpc: '2.0',
+        method: 'evm_revert',
+        params: [snapshot],
+      }),
+    });
+    const data = await response.json();
+    assert(data.result, 'Failed to revert snapshot');
+  }
+
+  before(async () => {
+    const ogVerbose = $.verbose;
+    $.verbose = false;
+
+    // Deploy core contracts on all chains
+    const [chain2Addresses, chain3Addresses, chain4Addresses] =
+      await Promise.all([
+        deployOrUseExistingCore(CHAIN_NAME_2, CORE_CONFIG_PATH, ANVIL_KEY),
+        deployOrUseExistingCore(CHAIN_NAME_3, CORE_CONFIG_PATH, ANVIL_KEY),
+        deployOrUseExistingCore(CHAIN_NAME_4, CORE_CONFIG_PATH, ANVIL_KEY),
       ]);
-      const tokenSymbol = await tokenChain2.symbol();
 
-      // Deploy Warp Route
-      const warpDeploymentPath = getCombinedWarpRoutePath(tokenSymbol, [
-        CHAIN_NAME_2,
-        CHAIN_NAME_3,
-        CHAIN_NAME_4,
-      ]);
-      const ownerAddress = new Wallet(ANVIL_KEY).address;
-      const warpConfig: WarpRouteDeployConfig = {
-        [CHAIN_NAME_2]: {
-          type: TokenType.collateral,
-          token: tokenChain2.address,
-          mailbox: chain2Addresses.mailbox,
-          owner: ownerAddress,
-        },
-        [CHAIN_NAME_3]: {
-          type: TokenType.collateral,
-          token: tokenChain3.address,
-          mailbox: chain3Addresses.mailbox,
-          owner: ownerAddress,
-        },
-        [CHAIN_NAME_4]: {
-          type: TokenType.synthetic,
-          mailbox: chain4Addresses.mailbox,
-          owner: ownerAddress,
-        },
-      };
-      writeYamlOrJson(warpDeploymentPath, warpConfig);
-      await hyperlaneWarpDeploy(warpDeploymentPath);
+    // Deploy ERC20s
+    const [tokenChain2, tokenChain3] = await Promise.all([
+      deployToken(ANVIL_KEY, CHAIN_NAME_2),
+      deployToken(ANVIL_KEY, CHAIN_NAME_3),
+    ]);
+    tokenSymbol = await tokenChain2.symbol();
 
-      // Bridge tokens from the collateral chains to the synthetic
+    // Deploy Warp Route
+    warpDeploymentPath = getCombinedWarpRoutePath(tokenSymbol, [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+      CHAIN_NAME_4,
+    ]);
+    const ownerAddress = new Wallet(ANVIL_KEY).address;
+    const warpConfig: WarpRouteDeployConfig = {
+      [CHAIN_NAME_2]: {
+        type: TokenType.collateral,
+        token: tokenChain2.address,
+        mailbox: chain2Addresses.mailbox,
+        owner: ownerAddress,
+      },
+      [CHAIN_NAME_3]: {
+        type: TokenType.collateral,
+        token: tokenChain3.address,
+        mailbox: chain3Addresses.mailbox,
+        owner: ownerAddress,
+      },
+      [CHAIN_NAME_4]: {
+        type: TokenType.synthetic,
+        mailbox: chain4Addresses.mailbox,
+        owner: ownerAddress,
+      },
+    };
+    writeYamlOrJson(warpDeploymentPath, warpConfig);
+    await hyperlaneWarpDeploy(warpDeploymentPath);
+
+    warpRouteId = createWarpRouteConfigId(tokenSymbol.toUpperCase(), [
+      CHAIN_NAME_2,
+      CHAIN_NAME_3,
+      CHAIN_NAME_4,
+    ]);
+
+    $.verbose = ogVerbose;
+  });
+
+  beforeEach(async () => {
+    process = undefined;
+
+    snapshot1 = await createSnapshot('http://localhost:8555');
+    snapshot2 = await createSnapshot('http://localhost:8600');
+    snapshot3 = await createSnapshot('http://localhost:8601');
+  });
+
+  afterEach(async () => {
+    if (process) {
+      await process.kill();
+    }
+
+    await restoreSnapshot('http://localhost:8555', snapshot1);
+    await restoreSnapshot('http://localhost:8600', snapshot2);
+    await restoreSnapshot('http://localhost:8601', snapshot3);
+  });
+
+  it('should successfuly start the rebalancer', async () => {
+    process = hyperlaneWarpRebalancer(warpRouteId, CHECK_FREQUENCY);
+
+    for await (const chunk of process.stdout) {
+      if (chunk.includes('Rebalancer started successfully 🚀')) {
+        break;
+      }
+    }
+  });
+
+  describe('with no balance on collateral contracts', () => {
+    it('should report an empty array of routes being executed', async () => {
+      process = hyperlaneWarpRebalancer(warpRouteId, CHECK_FREQUENCY);
+
+      for await (const chunk of process.stdout) {
+        if (chunk.includes('Executing rebalancing routes: []')) {
+          break;
+        }
+      }
+    });
+  });
+
+  describe('with the same balance on all collateral contracts', () => {
+    beforeEach(async () => {
+      const ogVerbose = $.verbose;
+      $.verbose = false;
+
       await Promise.all([
         hyperlaneWarpSendRelay(
           CHAIN_NAME_2,
           CHAIN_NAME_4,
           warpDeploymentPath,
           true,
-          toWei(49),
+          toWei(50),
         ),
         hyperlaneWarpSendRelay(
           CHAIN_NAME_3,
           CHAIN_NAME_4,
           warpDeploymentPath,
           true,
-          toWei(51),
+          toWei(50),
         ),
       ]);
 
-      // Start the rebalancer
-      const warpRouteId = createWarpRouteConfigId(tokenSymbol.toUpperCase(), [
-        CHAIN_NAME_2,
-        CHAIN_NAME_3,
-        CHAIN_NAME_4,
-      ]);
-      const process = hyperlaneWarpRebalancer(warpRouteId, 1000);
+      $.verbose = ogVerbose;
+    });
 
-      // Verify that it logs an expected output
+    it('should report an empty array of routes being executed', async () => {
+      process = hyperlaneWarpRebalancer(warpRouteId, CHECK_FREQUENCY);
+
+      for await (const chunk of process.stdout) {
+        if (chunk.includes('Executing rebalancing routes: []')) {
+          break;
+        }
+      }
+    });
+  });
+
+  describe('with different balances on collateral contracts', () => {
+    beforeEach(async () => {
+      const ogVerbose = $.verbose;
+      $.verbose = false;
+
+      await Promise.all([
+        hyperlaneWarpSendRelay(
+          CHAIN_NAME_2,
+          CHAIN_NAME_4,
+          warpDeploymentPath,
+          true,
+          toWei(30),
+        ),
+        hyperlaneWarpSendRelay(
+          CHAIN_NAME_3,
+          CHAIN_NAME_4,
+          warpDeploymentPath,
+          true,
+          toWei(70),
+        ),
+      ]);
+
+      $.verbose = ogVerbose;
+    });
+
+    it('should report an array of routes being executed', async () => {
+      process = hyperlaneWarpRebalancer(warpRouteId, CHECK_FREQUENCY);
+
       for await (const chunk of process.stdout) {
         if (
-          chunk.includes(`Executing rebalancing routes: [
+          chunk.includes(
+            `Executing rebalancing routes: [
   {
     fromChain: 'anvil3',
     toChain: 'anvil2',
-    amount: 1000000000000000000n
+    amount: 20000000000000000000n
   }
-]`)
+]`,
+          )
         ) {
-          process.kill();
           break;
         }
       }


### PR DESCRIPTION
Closes #26 
Closes #27 
Closes #28 

- Parallelize some tasks so rebalancer tests build up faster
- Adds a tolerance to the simple strat so chains that are close to the balance target don't need to be rebalanced
- Adds helper functions to create and restore snapshots