### PR TITLE
refactor: monitor

### DIFF
--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -34,6 +34,7 @@ import {
   IMonitor,
   IStrategy,
   Monitor,
+  MonitorRunError,
   Strategy,
 } from '../rebalancer/index.js';
 import { sendTestTransfer } from '../send/transfer.js';
@@ -478,9 +479,12 @@ export const rebalancer: CommandModuleWithContext<{
         })
         // Observe monitor errors and exit
         .on('error', (e) => {
-          throw new Error(
-            `Something went wrong with the monitor: ${e.message}`,
-          );
+          if (e instanceof MonitorRunError) {
+            errorRed(e);
+          } else {
+            // This will catch `MonitorStartError` and generic errors
+            throw e;
+          }
         })
         // Observe monitor start and log success
         .on('start', () => {

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -460,9 +460,9 @@ export const rebalancer: CommandModuleWithContext<{
       // Instantiates the executor that will process rebalancing routes
       const executor: IExecutor = new Executor();
 
-      monitor
-        // Observe monitor events and process rebalancing routes
-        .on('monitor', (event) => {
+      await monitor
+        // Observe balances events and process rebalancing routes
+        .on('collateralbalances', (event) => {
           const balances = event.balances.reduce((acc, next) => {
             acc[next.chain] = next.value;
             return acc;

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -446,38 +446,50 @@ export const rebalancer: CommandModuleWithContext<{
     checkFrequency,
     strategyConfigFile,
   }) => {
-    try {
-      // Instantiates the warp route monitor
-      const monitor: IMonitor = new Monitor(
-        context.registry,
-        warpRouteId,
-        checkFrequency,
-      );
+    // Instantiates the warp route monitor
+    const monitor: IMonitor = new Monitor(
+      context.registry,
+      warpRouteId,
+      checkFrequency,
+    );
 
+    try {
       // Instantiates the strategy that will get rebalancing routes based on monitor results
       const strategy: IStrategy = Strategy.fromConfigFile(strategyConfigFile);
 
       // Instantiates the executor that will process rebalancing routes
       const executor: IExecutor = new Executor();
 
-      // Observe monitor events and process rebalancing routes
-      monitor.subscribe((event) => {
-        const balances = event.balances.reduce((acc, next) => {
-          acc[next.chain] = next.value;
-          return acc;
-        }, {} as Record<ChainName, bigint>);
+      monitor
+        // Observe monitor events and process rebalancing routes
+        .on('monitor', (event) => {
+          const balances = event.balances.reduce((acc, next) => {
+            acc[next.chain] = next.value;
+            return acc;
+          }, {} as Record<ChainName, bigint>);
 
-        const rebalancingRoutes = strategy.getRebalancingRoutes(balances);
+          const rebalancingRoutes = strategy.getRebalancingRoutes(balances);
 
-        executor.processRebalancingRoutes(rebalancingRoutes);
-      });
-
-      // Starts the monitor to begin polling balances.
-      await monitor.start();
-
-      logGreen('Rebalancer started successfully 🚀');
+          executor.processRebalancingRoutes(rebalancingRoutes).catch((e) => {
+            throw new Error(
+              `Error processing rebalancing routes: ${e.messages}`,
+            );
+          });
+        })
+        // Observe monitor errors and exit
+        .on('error', (e) => {
+          throw new Error(
+            `Something went wrong with the monitor: ${e.message}`,
+          );
+        })
+        // Observe monitor start and log success
+        .on('start', () => {
+          logGreen('Rebalancer started successfully 🚀');
+        })
+        // Finally, starts the monitor to begin polling balances.
+        .start();
     } catch (e) {
-      errorRed('Rebalancer could not be started:', (e as Error).message);
+      errorRed('Error on the rebalancer:', (e as Error).message);
       process.exit(1);
     }
   },

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -446,14 +446,14 @@ export const rebalancer: CommandModuleWithContext<{
     checkFrequency,
     strategyConfigFile,
   }) => {
-    // Instantiates the warp route monitor
-    const monitor: IMonitor = new Monitor(
-      context.registry,
-      warpRouteId,
-      checkFrequency,
-    );
-
     try {
+      // Instantiates the warp route monitor
+      const monitor: IMonitor = new Monitor(
+        context.registry,
+        warpRouteId,
+        checkFrequency,
+      );
+
       // Instantiates the strategy that will get rebalancing routes based on monitor results
       const strategy: IStrategy = Strategy.fromConfigFile(strategyConfigFile);
 

--- a/typescript/cli/src/commands/warp.ts
+++ b/typescript/cli/src/commands/warp.ts
@@ -34,7 +34,7 @@ import {
   IMonitor,
   IStrategy,
   Monitor,
-  MonitorRunError,
+  MonitorPollingError,
   Strategy,
 } from '../rebalancer/index.js';
 import { sendTestTransfer } from '../send/transfer.js';
@@ -479,7 +479,7 @@ export const rebalancer: CommandModuleWithContext<{
         })
         // Observe monitor errors and exit
         .on('error', (e) => {
-          if (e instanceof MonitorRunError) {
+          if (e instanceof MonitorPollingError) {
             errorRed(e);
           } else {
             // This will catch `MonitorStartError` and generic errors

--- a/typescript/cli/src/rebalancer/interfaces/IMonitor.ts
+++ b/typescript/cli/src/rebalancer/interfaces/IMonitor.ts
@@ -36,10 +36,25 @@ export interface IMonitor {
   /**
    * Allows subscribers to listen to monitored token data whenever it is emitted.
    */
-  subscribe(fn: (event: MonitorEvent) => void): void;
+  on(eventName: 'monitor', fn: (event: MonitorEvent) => void): this;
+
+  /**
+   * Allows subscribers to listen to error events.
+   */
+  on(eventName: 'error', fn: (event: Error) => void): this;
+
+  /**
+   * Allows subscribers to listen to start events.
+   */
+  on(eventName: 'start', fn: () => void): this;
 
   /**
    * Starts the monitoring long-running process.
    */
   start(): Promise<void>;
+
+  /**
+   * Stops the monitoring long-running process.
+   */
+  stop(): void;
 }

--- a/typescript/cli/src/rebalancer/interfaces/IMonitor.ts
+++ b/typescript/cli/src/rebalancer/interfaces/IMonitor.ts
@@ -34,9 +34,9 @@ export type MonitorEvent = {
  */
 export interface IMonitor {
   /**
-   * Allows subscribers to listen to monitored token data whenever it is emitted.
+   * Allows subscribers to listen to collateral balances.
    */
-  on(eventName: 'monitor', fn: (event: MonitorEvent) => void): this;
+  on(eventName: 'collateralbalances', fn: (event: MonitorEvent) => void): this;
 
   /**
    * Allows subscribers to listen to error events.

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -4,19 +4,8 @@ import { IRegistry } from '@hyperlane-xyz/registry';
 import { MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
 import { objMap, objMerge, sleep } from '@hyperlane-xyz/utils';
 
+import { WrappedError } from '../../utils/errors.js';
 import { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
-
-class WrappedError extends Error {
-  constructor(message: string, originalError?: Error) {
-    super(message);
-    this.name = 'WrappedError';
-
-    // Preserve the stack trace of the original error if available
-    if (originalError?.stack) {
-      this.stack = `${this.stack}\nCaused by: ${originalError.stack}`;
-    }
-  }
-}
 
 export class MonitorStartError extends WrappedError {
   name = 'MonitorStartError';

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -1,9 +1,8 @@
 import EventEmitter from 'events';
 
 import { IRegistry } from '@hyperlane-xyz/registry';
-import { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
-import { WarpCore } from '@hyperlane-xyz/sdk';
-import { objMap, objMerge } from '@hyperlane-xyz/utils';
+import { MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
+import { objMap, objMerge, sleep } from '@hyperlane-xyz/utils';
 
 import { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
 
@@ -11,9 +10,8 @@ import { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
  * Simple monitor implementation that polls warp route collateral balances and emits them as MonitorEvent.
  */
 export class Monitor implements IMonitor {
-  private readonly MONITOR_EVENT = 'monitor';
   private readonly emitter = new EventEmitter();
-  private interval: NodeJS.Timeout | undefined;
+  private isMonitorRunning = false;
 
   /**
    * @param registry - The registry that contains a collection of configs, artifacts, and schemas for Hyperlane.
@@ -26,51 +24,71 @@ export class Monitor implements IMonitor {
     private readonly checkFrequency: number,
   ) {}
 
-  subscribe(fn: (data: MonitorEvent) => void) {
-    this.emitter.on(this.MONITOR_EVENT, fn);
+  on(eventName: 'monitor' | 'start' | 'error', fn: (...args: any[]) => void) {
+    this.emitter.on(eventName, fn);
+    return this;
   }
 
   async start() {
-    if (this.interval) {
+    if (this.isMonitorRunning) {
       // Cannot start the same monitor multiple times
-      throw new Error('Monitor already running');
+      this.emitter.emit('error', new Error('Monitor already running'));
     }
 
-    // Build the WarpCore from the registry
-    const metadata = await this.registry.getMetadata();
-    const addresses = await this.registry.getAddresses();
-    const mailboxes = objMap(addresses, (_, { mailbox }) => ({ mailbox }));
-    const provider = new MultiProtocolProvider(objMerge(metadata, mailboxes));
-    const warpCoreConfig = await this.registry.getWarpRoute(this.warpRouteId);
-    const warpCore = WarpCore.FromConfig(provider, warpCoreConfig);
+    try {
+      this.isMonitorRunning = true;
 
-    // Start the interval used to poll collateral balances
-    this.interval = setInterval(async () => {
-      const event: MonitorEvent = {
-        balances: [],
-      };
+      // Build the WarpCore from the registry
+      const metadata = await this.registry.getMetadata();
+      const addresses = await this.registry.getAddresses();
 
-      for (const token of warpCore.tokens) {
-        // Ignore non-collateralized tokens given that we only care about collateral balances
-        if (!token.isCollateralized()) {
-          continue;
+      // The Sealevel warp adapters require the Mailbox address, so we
+      // get mailboxes for all chains and merge them with the chain metadata.
+      const mailboxes = objMap(addresses, (_, { mailbox }) => ({ mailbox }));
+      const provider = new MultiProtocolProvider(objMerge(metadata, mailboxes));
+      const warpCoreConfig = await this.registry.getWarpRoute(this.warpRouteId);
+      const warpCore = WarpCore.FromConfig(provider, warpCoreConfig);
+
+      // this can be considered the starting point of the monitor
+      this.emitter.emit('start');
+
+      while (this.isMonitorRunning) {
+        const event: MonitorEvent = {
+          balances: [],
+        };
+
+        for (const token of warpCore.tokens) {
+          // Ignore non-collateralized tokens given that we only care about collateral balances
+          if (!token.isCollateralized()) {
+            continue;
+          }
+
+          const adapter = token.getHypAdapter(warpCore.multiProvider);
+
+          // Get the bridged supply of the collateral token to obtain how much collateral is available
+          const bridgedSupply = await adapter.getBridgedSupply();
+
+          event.balances.push({
+            chain: token.chainName,
+            owner: token.addressOrDenom,
+            token: token.collateralAddressOrDenom!,
+            value: bridgedSupply!,
+          });
         }
 
-        const adapter = token.getHypAdapter(warpCore.multiProvider);
+        // Emit the event containing the collateral balances
+        this.emitter.emit('monitor', event);
 
-        // Get the bridged supply of the collateral token to obtain how much collateral is available
-        const bridgedSupply = await adapter.getBridgedSupply();
-
-        event.balances.push({
-          chain: token.chainName,
-          owner: token.addressOrDenom,
-          token: token.collateralAddressOrDenom!,
-          value: bridgedSupply!,
-        });
+        // Wait for the specified check frequency before the next iteration
+        await sleep(this.checkFrequency);
       }
+    } catch (e) {
+      this.emitter.emit('error', e);
+    }
+  }
 
-      // Emit the event containing the collateral balances
-      this.emitter.emit(this.MONITOR_EVENT, event);
-    }, this.checkFrequency);
+  stop() {
+    this.isMonitorRunning = false;
+    this.emitter.removeAllListeners();
   }
 }

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -22,8 +22,8 @@ export class MonitorStartError extends WrappedError {
   name = 'MonitorStartError';
 }
 
-export class MonitorRunError extends WrappedError {
-  name = 'MonitorRunError';
+export class MonitorPollingError extends WrappedError {
+  name = 'MonitorPollingError';
 }
 
 /**
@@ -109,7 +109,7 @@ export class Monitor implements IMonitor {
         } catch (e) {
           this.emitter.emit(
             'error',
-            new MonitorRunError(
+            new MonitorPollingError(
               `Error during monitor execution cycle: ${(e as Error).message}`,
               e as Error,
             ),

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -36,6 +36,7 @@ export class Monitor implements IMonitor {
     if (this.isMonitorRunning) {
       // Cannot start the same monitor multiple times
       this.emitter.emit('error', new Error('Monitor already running'));
+      return;
     }
 
     try {

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -24,7 +24,10 @@ export class Monitor implements IMonitor {
     private readonly checkFrequency: number,
   ) {}
 
-  on(eventName: 'monitor' | 'start' | 'error', fn: (...args: any[]) => void) {
+  on(
+    eventName: 'collateralbalances' | 'start' | 'error',
+    fn: (...args: any[]) => void,
+  ) {
     this.emitter.on(eventName, fn);
     return this;
   }
@@ -77,7 +80,7 @@ export class Monitor implements IMonitor {
         }
 
         // Emit the event containing the collateral balances
-        this.emitter.emit('monitor', event);
+        this.emitter.emit('collateralbalances', event);
 
         // Wait for the specified check frequency before the next iteration
         await sleep(this.checkFrequency);

--- a/typescript/cli/src/rebalancer/monitor/Monitor.ts
+++ b/typescript/cli/src/rebalancer/monitor/Monitor.ts
@@ -6,6 +6,26 @@ import { objMap, objMerge, sleep } from '@hyperlane-xyz/utils';
 
 import { IMonitor, MonitorEvent } from '../interfaces/IMonitor.js';
 
+class WrappedError extends Error {
+  constructor(message: string, originalError?: Error) {
+    super(message);
+    this.name = 'WrappedError';
+
+    // Preserve the stack trace of the original error if available
+    if (originalError?.stack) {
+      this.stack = `${this.stack}\nCaused by: ${originalError.stack}`;
+    }
+  }
+}
+
+export class MonitorStartError extends WrappedError {
+  name = 'MonitorStartError';
+}
+
+export class MonitorRunError extends WrappedError {
+  name = 'MonitorRunError';
+}
+
 /**
  * Simple monitor implementation that polls warp route collateral balances and emits them as MonitorEvent.
  */
@@ -35,7 +55,10 @@ export class Monitor implements IMonitor {
   async start() {
     if (this.isMonitorRunning) {
       // Cannot start the same monitor multiple times
-      this.emitter.emit('error', new Error('Monitor already running'));
+      this.emitter.emit(
+        'error',
+        new MonitorStartError('Monitor already running'),
+      );
       return;
     }
 
@@ -57,37 +80,53 @@ export class Monitor implements IMonitor {
       this.emitter.emit('start');
 
       while (this.isMonitorRunning) {
-        const event: MonitorEvent = {
-          balances: [],
-        };
+        try {
+          const event: MonitorEvent = {
+            balances: [],
+          };
 
-        for (const token of warpCore.tokens) {
-          // Ignore non-collateralized tokens given that we only care about collateral balances
-          if (!token.isCollateralized()) {
-            continue;
+          for (const token of warpCore.tokens) {
+            // Ignore non-collateralized tokens given that we only care about collateral balances
+            if (!token.isCollateralized()) {
+              continue;
+            }
+
+            const adapter = token.getHypAdapter(warpCore.multiProvider);
+
+            // Get the bridged supply of the collateral token to obtain how much collateral is available
+            const bridgedSupply = await adapter.getBridgedSupply();
+
+            event.balances.push({
+              chain: token.chainName,
+              owner: token.addressOrDenom,
+              token: token.collateralAddressOrDenom!,
+              value: bridgedSupply!,
+            });
           }
 
-          const adapter = token.getHypAdapter(warpCore.multiProvider);
-
-          // Get the bridged supply of the collateral token to obtain how much collateral is available
-          const bridgedSupply = await adapter.getBridgedSupply();
-
-          event.balances.push({
-            chain: token.chainName,
-            owner: token.addressOrDenom,
-            token: token.collateralAddressOrDenom!,
-            value: bridgedSupply!,
-          });
+          // Emit the event containing the collateral balances
+          this.emitter.emit('collateralbalances', event);
+        } catch (e) {
+          this.emitter.emit(
+            'error',
+            new MonitorRunError(
+              `Error during monitor execution cycle: ${(e as Error).message}`,
+              e as Error,
+            ),
+          );
         }
-
-        // Emit the event containing the collateral balances
-        this.emitter.emit('collateralbalances', event);
 
         // Wait for the specified check frequency before the next iteration
         await sleep(this.checkFrequency);
       }
     } catch (e) {
-      this.emitter.emit('error', e);
+      this.emitter.emit(
+        'error',
+        new MonitorStartError(
+          `Error starting monitor: ${(e as Error).message}`,
+          e as Error,
+        ),
+      );
     }
   }
 

--- a/typescript/cli/src/tests/commands/helpers.ts
+++ b/typescript/cli/src/tests/commands/helpers.ts
@@ -520,8 +520,8 @@ export function hyperlaneRelayer(chains: string[], warp?: string) {
         --yes`;
 }
 
-export async function createSnapshot(rpcUrl: string): Promise<string> {
-  return await snapshotBaseCall<string>(rpcUrl, 'evm_snapshot', []);
+export function createSnapshot(rpcUrl: string) {
+  return snapshotBaseCall<string>(rpcUrl, 'evm_snapshot', []);
 }
 
 export async function restoreSnapshot(

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -159,11 +159,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
   });
 
   afterEach(async () => {
-    try {
-      rmSync(REBALANCER_STRATEGY_CONFIG_PATH);
-    } catch (e) {
-      // Ignore
-    }
+    rmSync(REBALANCER_STRATEGY_CONFIG_PATH, { force: true });
 
     await Promise.all(
       snapshots.map(({ rpcUrl, snapshotId }) =>
@@ -172,7 +168,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     );
   });
 
-  async function startRebalancerAndExpectLog(
+  function startRebalancerAndExpectLog(
     log: string,
     timeout = 10000,
   ): Promise<void> {
@@ -182,6 +178,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
       REBALANCER_STRATEGY_CONFIG_PATH,
     );
 
+    // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       const timeoutId = setTimeout(async () => {
         await process.kill();
@@ -205,7 +202,7 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     });
   }
 
-  it('should successfuly start the rebalancer', async () => {
+  it('should successfully start the rebalancer', async () => {
     await startRebalancerAndExpectLog('Rebalancer started successfully 🚀');
   });
 
@@ -217,14 +214,16 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
     );
   });
 
-  it('should throw if a strategy bigint cannot be parsed', async () => {
+  it('should throw if a weight value cannot be parsed as bigint', async () => {
     writeYamlOrJson(REBALANCER_STRATEGY_CONFIG_PATH, {
       [CHAIN_NAME_2]: { weight: 'weight', tolerance: 0 },
       [CHAIN_NAME_3]: { weight: 100, tolerance: 0 },
     });
 
     await startRebalancerAndExpectLog(`Cannot convert weight to a BigInt`);
+  });
 
+  it('should throw if a tolerance value cannot be parsed as bigint', async () => {
     writeYamlOrJson(REBALANCER_STRATEGY_CONFIG_PATH, {
       [CHAIN_NAME_2]: { weight: 100, tolerance: 0 },
       [CHAIN_NAME_3]: { weight: 100, tolerance: 'tolerance' },

--- a/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
+++ b/typescript/cli/src/tests/warp/warp-rebalancer.e2e-test.ts
@@ -191,7 +191,9 @@ describe('hyperlane warp rebalancer e2e tests', async function () {
         reject(e.text());
       });
 
-      for await (const chunk of process.stdout) {
+      for await (let chunk of process.stdout) {
+        chunk = typeof chunk === 'string' ? chunk : chunk.toString();
+
         if (chunk.includes(log)) {
           clearTimeout(timeoutId);
           resolve();

--- a/typescript/cli/src/utils/errors.ts
+++ b/typescript/cli/src/utils/errors.ts
@@ -1,0 +1,11 @@
+export class WrappedError extends Error {
+  constructor(message: string, originalError?: Error) {
+    super(message);
+    this.name = 'WrappedError';
+
+    // Preserve the stack trace of the original error if available
+    if (originalError?.stack) {
+      this.stack = `${this.stack}\nCaused by: ${originalError.stack}`;
+    }
+  }
+}


### PR DESCRIPTION
Closes #21.

Rebalancer's monitor now behaves the same way as in the infra monitor. Ensuring the spaced iterations between calls.

Tests were adjusted.

Monitor is now event-based. You can subscribe to `collateralbalances`, `start`, and `error` to handle the Monitor instance.


